### PR TITLE
504 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Without the -n option all files in the container will be downloaded.
 
 ## Command Options
 
-- `-f`, `--file` *string* URL, file or files (e.g. /data/*.gz) to upload. Destination file for download scenarios.
+- `-f`, `--file` *string* URL, file or files (e.g. /data/*.gz) to upload.
 
 - `-c`, `--container_name` *string* container name (e.g. `mycontainer`).
 

--- a/targets/azureblock.go
+++ b/targets/azureblock.go
@@ -70,9 +70,9 @@ func convertToStorageBlockList(list interface{}, numOfBlocks int) []storage.Bloc
 }
 
 //PreProcessSourceInfo implementation of PreProcessSourceInfo from the pipeline.TargetPipeline interface.
-//Passthrough no need to pre-process for blob blocks.
+//Checks if uncommitted blocks are present and cleans them by creating an empty blob.
 func (t AzureBlock) PreProcessSourceInfo(source *pipeline.SourceInfo) (err error) {
-	return nil
+	return util.CleanUncommittedBlocks(&t.StorageClient, t.Container, source.TargetAlias)
 }
 
 //ProcessWrittenPart implements ProcessWrittenPart from the pipeline.TargetPipeline interface.

--- a/targets/azurepage.go
+++ b/targets/azurepage.go
@@ -32,7 +32,7 @@ func NewAzurePage(accountName string, accountKey string, container string) pipel
 const PageSize int64 = 512
 
 //PreProcessSourceInfo implementation of PreProcessSourceInfo from the pipeline.TargetPipeline interface.
-//Passthrough no need to pre-process for blob blocks.
+//initializes the page blob.
 func (t AzurePage) PreProcessSourceInfo(source *pipeline.SourceInfo) (err error) {
 	size := int64(source.Size)
 

--- a/transfer/transfer_test.go
+++ b/transfer/transfer_test.go
@@ -187,7 +187,7 @@ func TestFileToBlobToFile(t *testing.T) {
 	tfer.WaitForCompletion()
 
 	ap = targets.NewMultiFile(true, numOfWorkers)
-	fp = sources.NewAzureBlob(container, []string{sourceFile}, accountName, accountKey, true)
+	fp = sources.NewAzureBlob(container, []string{sourceFile}, accountName, accountKey, true, false)
 	tfer = NewTransfer(&fp, &ap, numOfReaders, numOfWorkers, blockSize)
 	tfer.StartTransfer(None, delegate)
 	tfer.WaitForCompletion()
@@ -207,7 +207,7 @@ func TestFileToBlobToFileWithAlias(t *testing.T) {
 	tfer.WaitForCompletion()
 
 	ap = targets.NewMultiFile(true, numOfWorkers)
-	fp = sources.NewAzureBlob(container, []string{alias}, accountName, accountKey, true)
+	fp = sources.NewAzureBlob(container, []string{alias}, accountName, accountKey, true, false)
 	tfer = NewTransfer(&fp, &ap, numOfReaders, numOfWorkers, blockSize)
 	tfer.StartTransfer(None, delegate)
 	tfer.WaitForCompletion()


### PR DESCRIPTION
- Download scenarios handle the API pagination (markers)
- New option, -e forces an exact match instead of prefix name matching
- Retry attempts increased to 100
- Uncommited blocks are deleted if detected.