### PR TITLE
 - Batch transfers, 200 files at the time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ _build/windows_amd64
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out
+debug
 
 *.cgo1.go
 *.cgo2.c

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ _build/windows_amd64
 *.[568vq]
 [568vq].out
 debug
-
+.vscode
 *.cgo1.go
 *.cgo2.c
 _cgo_defun.c

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,8 +11,11 @@
             "port": 2345,
             "host": "127.0.0.1",
             "program": "${fileDirname}",
-            "env": {},
-            "args": [" -f \"http://video.ch9.ms/ch9/d36c/6cfce1e3-63e5-47a7-b3b6-8c813a23d36c/SnackPackPlanetXamarin.mp3\" -f \"http://video.ch9.ms/ch9/d36c/6cfce1e3-63e5-47a7-b3b6-8c813a23d36c/SnackPackPlanetXamarin.mp3\" -n v1.mp3 -n v2.mp3 -t http-file "] ,
+            "env": {
+                "ACCOUNT_NAME":"storagejaa",
+                "ACCOUNT_KEY":"/mXWG4aXMWvftzR+Ed5URccwrDSvvv5cUsKCqq5gbyPXvtlyfQ9gjq462kuH/2dErjwR8QcAS74vLaNXynd74g=="
+            },
+            "args": ["-c", "many", "-t","blob-file","-p"] ,
             "showLog": true
         }
     ]

--- a/inttest._m.sh
+++ b/inttest._m.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+DOWN_F1=dref.blob
+DOWN_P1=dref.vhd
+WORKING_DIR=wd
+F1=$WORKING_DIR"/"ref.blob
+P1=$WORKING_DIR"/"ref.vhd
+
+CONT="bptest"
+
+calculateMD5 () {
+REF_MD5="$(md5sum $1 | awk '{print $1}')"
+VAL_MD5="$(md5sum $2 | awk '{print $1}')"
+
+if [ "$REF_MD5" = "$VAL_MD5" ] ; then
+    echo "Success!"
+else
+    echo $REF_MD5
+    echo $VAL_MD5
+    echo "Failure!"
+    exit 1
+fi
+}
+
+#Create random files for testing...
+echo "Creating working files..."
+mkdir -p $WORKING_DIR
+
+dd if=/dev/urandom of=$F1 bs=64M count=1 iflag=fullblock
+dd if=/dev/urandom of=$P1 bs=64M count=1 iflag=fullblock
+
+
+#Scenario 1 - Simple upload/download with default values
+#Upload file
+./blobporter -f $F1 -c $CONT -n $DOWN_F1
+
+#Download file
+./blobporter -c $CONT -n $DOWN_F1 -t blob-file
+calculateMD5 $F1 $DOWN_F1
+
+#Scenario 2 - Simple page upload/download with default values
+#Upload vhd
+./blobporter -f $P1 -c $CONT -n $DOWN_P1 -t file-pageblob
+
+#Download vhd
+./blobporter -n $DOWN_P1 -c $CONT  -t pageblob-file
+calculateMD5 $P1 $DOWN_P1
+
+#Scenario 3 - Silent page upload/download with default values
+#Upload vhd
+./blobporter -f $P1 -c $CONT -n $DOWN_p1  -t file-pageblob -q
+#Download vhd
+./blobporter -n $DOWN_P1 -c $CONT -t pageblob-file -q
+calculateMD5 $P1 $DOWN_P1
+
+#Scenario 4 - Silent page upload/download with default values and md5
+#Upload vhd
+./blobporter -f $P1 -c $CONT -t -n $DOWN_p1  file-pageblob -q -m
+#Download vhd
+./blobporter -n $DOWN_P1 -c $CONT -t pageblob-file -q -m
+calculateMD5 $P1 $DOWN_P1
+
+#Scenario 5 - Simple upload/download with default values and md5
+#Upload file
+./blobporter -f $F1 -c $CONT -n $DOWN_F1  -m
+#Download file
+./blobporter -n $DOWN_F1 -c $CONT -t blob-file -m
+calculateMD5 $F1 $DOWN_F1
+
+#Scenario 6 - Simple download from a HTTP source
+URL=http://video.ch9.ms/ch9/a44c/d57e542a-665a-4fdd-a29a-12c606fda44c/IntroASPNETMVCM01_mid.mp4
+wget -O vd1f.mp4 $URL
+./blobporter -f $URL -n vd1.mp4 -t http-file
+calculateMD5 vd1.mp4 vd1f.mp4
+
+
+#Scenario 7 - Simple upload/download with 16MB
+#Upload file
+./blobporter -f $F1 -c $CONT -n $DOWN_F1 -b 16MB
+
+#Download file
+./blobporter -n $DOWN_F1 -c $CONT -t blob-file -b 16MB
+calculateMD5 $F1 $DOWN_F1

--- a/inttest.sh
+++ b/inttest.sh
@@ -6,7 +6,8 @@ FILE_SIZE=5242880 #5MiB
 EXIT_CODE=0
 
 #create a temp file
-dd if=/dev/zero of=$REF_FILE bs=$FILE_SIZE count=1
+dd if=/dev/urandom of=$REF_FILE bs=64M count=1 iflag=fullblock
+
 
 #Set permissions
 sudo chmod +x ./linux_amd64/blobporter

--- a/sources/azureblob.go
+++ b/sources/azureblob.go
@@ -1,10 +1,10 @@
 package sources
 
 import (
+	"log"
+	"path"
 	"sync"
 	"time"
-
-	"log"
 
 	"fmt"
 
@@ -27,102 +27,144 @@ type AzureBlob struct {
 	storageClient  storage.BlobStorageClient
 }
 
-//NewAzureBlob creates a new instance of HTTPPipeline
-//Creates a SASURI to the blobName with an expiration of sasTokenNumberOfHours.
-//blobName is used as the target alias.
-func NewAzureBlob(container string, blobNames []string, accountName string, accountKey string, md5 bool, useExactNameMatch bool) pipeline.SourcePipeline {
-	azureSource := AzureBlob{Container: container,
-		BlobNames:      blobNames,
-		storageClient:  util.GetBlobStorageClient(accountName, accountKey),
-		exactNameMatch: useExactNameMatch}
+//AzureBlobParams TODO
+type AzureBlobParams struct {
+	Container         string
+	BlobNames         []string
+	AccountName       string
+	AccountKey        string
+	CalculateMD5      bool
+	UseExactNameMatch bool
+	KeepDirStructure  bool
+	FilesPerPipeline  int
+}
 
-	if sourceURIs, err := azureSource.getSourceURIs(); err == nil {
-		httpSource := NewHTTP(sourceURIs, nil, md5)
-		azureSource.HTTPSource = httpSource.(HTTPPipeline)
-	} else {
+//NewAzureBlob creates a new instance of HTTPPipeline for Azure Blobs
+func NewAzureBlob(params *AzureBlobParams) []pipeline.SourcePipeline {
+
+	var err error
+	var sourceInfos []pipeline.SourceInfo
+	if sourceInfos, err = getSourcesInfoForBlobs(params); err != nil {
 		log.Fatal(err)
 	}
 
-	return azureSource
+	if params.FilesPerPipeline <= 0 {
+		log.Fatal(fmt.Errorf("Invalid operation. The number of files per batch must be greater than zero"))
+	}
+
+	numOfBatches := (len(sourceInfos) + params.FilesPerPipeline - 1) / params.FilesPerPipeline
+	pipelines := make([]pipeline.SourcePipeline, numOfBatches)
+	numOfFilesInBatch := params.FilesPerPipeline
+	filesSent := len(sourceInfos)
+	start := 0
+
+	for b := 0; b < numOfBatches; b++ {
+
+		if filesSent < numOfFilesInBatch {
+			numOfFilesInBatch = filesSent
+		}
+		start = b * numOfFilesInBatch
+
+		httpSource := HTTPPipeline{Sources: sourceInfos[start : start+numOfFilesInBatch], HTTPClient: util.NewHTTPClient(), includeMD5: params.CalculateMD5}
+		pipelines[b] = &AzureBlob{Container: params.Container,
+			BlobNames:      params.BlobNames,
+			HTTPSource:     httpSource,
+			storageClient:  util.GetBlobStorageClient(params.AccountName, params.AccountKey),
+			exactNameMatch: params.UseExactNameMatch}
+		filesSent = filesSent - numOfFilesInBatch
+	}
+
+	return pipelines
 }
 
 //GetSourcesInfo implements GetSourcesInfo from the pipeline.SourcePipeline Interface.
-func (f AzureBlob) GetSourcesInfo() []pipeline.SourceInfo {
+func (f *AzureBlob) GetSourcesInfo() []pipeline.SourceInfo {
 	return f.HTTPSource.GetSourcesInfo()
 }
 
 //ExecuteReader implements ExecuteReader from the pipeline.SourcePipeline Interface.
 //For each part the reader makes a byte range request to the source
 // starting from the part's Offset to BytesToRead - 1 (zero based).
-func (f AzureBlob) ExecuteReader(partitionsQ chan pipeline.PartsPartition, partsQ chan pipeline.Part, readPartsQ chan pipeline.Part, id int, wg *sync.WaitGroup) {
+func (f *AzureBlob) ExecuteReader(partitionsQ chan pipeline.PartsPartition, partsQ chan pipeline.Part, readPartsQ chan pipeline.Part, id int, wg *sync.WaitGroup) {
 	f.HTTPSource.ExecuteReader(partitionsQ, partsQ, readPartsQ, id, wg)
 }
 
 //ConstructBlockInfoQueue implements GetSourcesInfo from the pipeline.SourcePipeline Interface.
 //Constructs the Part's channel arithmetically from the size of the sources.
-func (f AzureBlob) ConstructBlockInfoQueue(blockSize uint64) (partitionsQ chan pipeline.PartsPartition, partsQ chan pipeline.Part, numOfBlocks int, size uint64) {
+func (f *AzureBlob) ConstructBlockInfoQueue(blockSize uint64) (partitionsQ chan pipeline.PartsPartition, partsQ chan pipeline.Part, numOfBlocks int, size uint64) {
 	return f.HTTPSource.ConstructBlockInfoQueue(blockSize)
 }
 
-func (f AzureBlob) getSourceURIs() ([]string, error) {
+func getSourcesInfoForBlobs(params *AzureBlobParams) ([]pipeline.SourceInfo, error) {
 	var err error
+	storageClient := util.GetBlobStorageClient(params.AccountName, params.AccountKey)
+
 	date := time.Now().UTC().Add(time.Duration(sasTokenNumberOfHours) * time.Hour)
 
 	var blobLists []storage.BlobListResponse
-	blobLists, err = f.getBlobLists()
+	blobLists, err = getBlobLists(params, &storageClient)
 	if err != nil {
 		return nil, err
 	}
 
-	sourceURIs := make([]string, 0)
+	sourceURIs := make([]pipeline.SourceInfo, 0)
 	var sourceURI string
 	for _, blobList := range blobLists {
 		for _, blob := range blobList.Blobs {
 
 			include := true
-			if f.exactNameMatch {
+			if params.UseExactNameMatch {
 				include = blob.Name == blobList.Prefix
 			}
 
 			if include {
-				sourceURI, err = f.storageClient.GetBlobSASURI(f.Container, blob.Name, date, "r")
+				sourceURI, err = storageClient.GetBlobSASURI(params.Container, blob.Name, date, "r")
 
 				if err != nil {
 					return nil, err
 				}
-				sourceURIs = append(sourceURIs, sourceURI)
+
+				targetAlias := blob.Name
+				if !params.KeepDirStructure {
+					targetAlias = path.Base(blob.Name)
+				}
+
+				sourceURIs = append(sourceURIs, pipeline.SourceInfo{
+					SourceName:  sourceURI,
+					Size:        uint64(blob.Properties.ContentLength),
+					TargetAlias: targetAlias})
 			}
 		}
 	}
 
 	if len(sourceURIs) == 0 {
 		nameMatchMode := "prefix"
-		if f.exactNameMatch {
+		if params.UseExactNameMatch {
 			nameMatchMode = "name"
 		}
-		return nil, fmt.Errorf("the %v %s did not match any blob names", nameMatchMode, f.BlobNames)
+		return nil, fmt.Errorf("the %v %s did not match any blob names", nameMatchMode, params.BlobNames)
 	}
 
 	return sourceURIs, nil
 }
 
-func (f AzureBlob) getBlobLists() ([]storage.BlobListResponse, error) {
+func getBlobLists(params *AzureBlobParams, client *storage.BlobStorageClient) ([]storage.BlobListResponse, error) {
 	var err error
 	listLength := 1
 
-	if len(f.BlobNames) > 1 {
-		listLength = len(f.BlobNames)
+	if len(params.BlobNames) > 1 {
+		listLength = len(params.BlobNames)
 	}
 
 	listOfLists := make([]storage.BlobListResponse, listLength)
 
-	for i, blobname := range f.BlobNames {
+	for i, blobname := range params.BlobNames {
 		var list *storage.BlobListResponse
-		params := storage.ListBlobsParameters{Prefix: blobname}
+		listParams := storage.ListBlobsParameters{Prefix: blobname}
 
 		for {
 			var listpage storage.BlobListResponse
-			if listpage, err = f.storageClient.ListBlobs(f.Container, params); err != nil {
+			if listpage, err = client.ListBlobs(params.Container, listParams); err != nil {
 				return nil, err
 			}
 
@@ -136,7 +178,7 @@ func (f AzureBlob) getBlobLists() ([]storage.BlobListResponse, error) {
 				break
 			}
 
-			params.Marker = listpage.NextMarker
+			listParams.Marker = listpage.NextMarker
 		}
 
 		listOfLists[i] = *list

--- a/targets/azurepage.go
+++ b/targets/azurepage.go
@@ -25,7 +25,7 @@ func NewAzurePage(accountName string, accountKey string, container string) pipel
 	util.CreateContainerIfNotExists(container, accountName, accountKey)
 	creds := pipeline.StorageAccountCredentials{AccountName: accountName, AccountKey: accountKey}
 	client := util.GetBlobStorageClient(creds.AccountName, creds.AccountKey)
-	return AzurePage{Creds: &creds, Container: container, StorageClient: &client}
+	return &AzurePage{Creds: &creds, Container: container, StorageClient: &client}
 }
 
 //PageSize size of page in Azure Page Blob storage
@@ -33,7 +33,7 @@ const PageSize int64 = 512
 
 //PreProcessSourceInfo implementation of PreProcessSourceInfo from the pipeline.TargetPipeline interface.
 //initializes the page blob.
-func (t AzurePage) PreProcessSourceInfo(source *pipeline.SourceInfo) (err error) {
+func (t *AzurePage) PreProcessSourceInfo(source *pipeline.SourceInfo) (err error) {
 	size := int64(source.Size)
 
 	if size%PageSize != 0 {
@@ -57,7 +57,7 @@ func (t AzurePage) PreProcessSourceInfo(source *pipeline.SourceInfo) (err error)
 
 //CommitList implements CommitList from the pipeline.TargetPipeline interface.
 //Passthrough no need to a commit for page blob.
-func (t AzurePage) CommitList(listInfo *pipeline.TargetCommittedListInfo, NumberOfBlocks int, targetName string) (msg string, err error) {
+func (t *AzurePage) CommitList(listInfo *pipeline.TargetCommittedListInfo, NumberOfBlocks int, targetName string) (msg string, err error) {
 
 	msg = "Page blob committed"
 	err = nil
@@ -66,7 +66,7 @@ func (t AzurePage) CommitList(listInfo *pipeline.TargetCommittedListInfo, Number
 
 //ProcessWrittenPart implements ProcessWrittenPart from the pipeline.TargetPipeline interface.
 //Passthrough no need to process a written part when transferring to a page blob.
-func (t AzurePage) ProcessWrittenPart(result *pipeline.WorkerResult, listInfo *pipeline.TargetCommittedListInfo) (requeue bool, err error) {
+func (t *AzurePage) ProcessWrittenPart(result *pipeline.WorkerResult, listInfo *pipeline.TargetCommittedListInfo) (requeue bool, err error) {
 	requeue = false
 	err = nil
 	return
@@ -75,7 +75,7 @@ func (t AzurePage) ProcessWrittenPart(result *pipeline.WorkerResult, listInfo *p
 //WritePart implements WritePart from the pipeline.TargetPipeline interface.
 //Performs a PUT page operation with the data contained in the part.
 //This assumes the part.BytesToRead is a multiple of the PageSize
-func (t AzurePage) WritePart(part *pipeline.Part) (duration time.Duration, startTime time.Time, numOfRetries int, err error) {
+func (t *AzurePage) WritePart(part *pipeline.Part) (duration time.Duration, startTime time.Time, numOfRetries int, err error) {
 
 	offset := int64(part.Offset)
 	endByte := int64(part.Offset + uint64(part.BytesToRead) - 1)

--- a/transfer/transfer_test.go
+++ b/transfer/transfer_test.go
@@ -25,6 +25,7 @@ var blockSize = uint64(4 * util.MiByte)
 var delegate = func(r pipeline.WorkerResult, committedCount int, bufferLevel int) {}
 var numOfReaders = 10
 var numOfWorkers = 10
+var filesPerPipeline = 10
 
 const (
 	containerName1 = "bptest"
@@ -36,7 +37,14 @@ func TestFileToPageHTTPToPage(t *testing.T) {
 
 	var sourceFile = createPageFile("tb", 1)
 
-	fp := sources.NewMultiFile([]string{sourceFile}, blockSize, nil, numOfReaders, true)
+	sourceParams := &sources.MultiFileParams{
+		SourcePatterns:   []string{sourceFile},
+		BlockSize:        blockSize,
+		FilesPerPipeline: filesPerPipeline,
+		NumOfPartitions:  numOfReaders,
+		MD5:              true}
+
+	fp := sources.NewMultiFile(sourceParams)[0]
 	ap := targets.NewAzurePage(accountName, accountKey, container)
 	tfer := NewTransfer(&fp, &ap, numOfReaders, numOfWorkers, blockSize)
 	tfer.StartTransfer(None, delegate)
@@ -58,7 +66,14 @@ func TestFileToPage(t *testing.T) {
 	var sourceFile = createPageFile("tb", 1)
 	container, _ := getContainers()
 
-	fp := sources.NewMultiFile([]string{sourceFile}, blockSize, nil, numOfReaders, true)
+	sourceParams := &sources.MultiFileParams{
+		SourcePatterns:   []string{sourceFile},
+		BlockSize:        blockSize,
+		FilesPerPipeline: filesPerPipeline,
+		NumOfPartitions:  numOfReaders,
+		MD5:              true}
+
+	fp := sources.NewMultiFile(sourceParams)[0]
 	pt := targets.NewAzurePage(accountName, accountKey, container)
 
 	tfer := NewTransfer(&fp, &pt, numOfReaders, numOfWorkers, blockSize)
@@ -72,7 +87,15 @@ func TestFileToFile(t *testing.T) {
 	var sourceFile = createFile("tb", 1)
 	var destFile = "d" + sourceFile
 
-	fp := sources.NewMultiFile([]string{sourceFile}, blockSize, []string{destFile}, numOfReaders, true)
+	sourceParams := &sources.MultiFileParams{
+		SourcePatterns:   []string{sourceFile},
+		BlockSize:        blockSize,
+		FilesPerPipeline: filesPerPipeline,
+		NumOfPartitions:  numOfReaders,
+		TargetAliases:    []string{destFile},
+		MD5:              true}
+
+	fp := sources.NewMultiFile(sourceParams)[0]
 	ft := targets.NewMultiFile(true, numOfWorkers)
 
 	tfer := NewTransfer(&fp, &ft, numOfReaders, numOfWorkers, blockSize)
@@ -88,7 +111,14 @@ func TestFileToBlob(t *testing.T) {
 	container, _ := getContainers()
 	var sourceFile = createFile("tb", 1)
 
-	fp := sources.NewMultiFile([]string{sourceFile}, blockSize, nil, numOfReaders, true)
+	sourceParams := &sources.MultiFileParams{
+		SourcePatterns:   []string{sourceFile},
+		BlockSize:        blockSize,
+		FilesPerPipeline: filesPerPipeline,
+		NumOfPartitions:  numOfReaders,
+		MD5:              true}
+
+	fp := sources.NewMultiFile(sourceParams)[0]
 	ap := targets.NewAzureBlock(accountName, accountKey, container)
 	tfer := NewTransfer(&fp, &ap, numOfReaders, numOfWorkers, blockSize)
 	tfer.StartTransfer(None, delegate)
@@ -102,7 +132,14 @@ func TestFileToBlobWithLargeBlocks(t *testing.T) {
 	var sourceFile = createFile("tb", 1)
 	bsize := uint64(16 * util.MiByte)
 
-	fp := sources.NewMultiFile([]string{sourceFile}, bsize, nil, numOfReaders, true)
+	sourceParams := &sources.MultiFileParams{
+		SourcePatterns:   []string{sourceFile},
+		BlockSize:        blockSize,
+		FilesPerPipeline: filesPerPipeline,
+		NumOfPartitions:  numOfReaders,
+		MD5:              true}
+
+	fp := sources.NewMultiFile(sourceParams)[0]
 	ap := targets.NewAzureBlock(accountName, accountKey, container)
 	tfer := NewTransfer(&fp, &ap, numOfReaders, numOfWorkers, bsize)
 	tfer.StartTransfer(None, delegate)
@@ -118,7 +155,14 @@ func TestFilesToBlob(t *testing.T) {
 	var sf3 = createFile("tbm", 1)
 	var sf4 = createFile("tbm", 1)
 
-	fp := sources.NewMultiFile([]string{"tbm*"}, blockSize, nil, numOfReaders, true)
+	sourceParams := &sources.MultiFileParams{
+		SourcePatterns:   []string{"tbm*"},
+		BlockSize:        blockSize,
+		FilesPerPipeline: filesPerPipeline,
+		NumOfPartitions:  numOfReaders,
+		MD5:              true}
+
+	fp := sources.NewMultiFile(sourceParams)[0]
 	ap := targets.NewAzureBlock(accountName, accountKey, container)
 	tfer := NewTransfer(&fp, &ap, numOfReaders, numOfWorkers, blockSize)
 	tfer.StartTransfer(None, delegate)
@@ -135,7 +179,14 @@ func TestFileToBlobHTTPToBlob(t *testing.T) {
 
 	var sourceFile = createFile("tb", 1)
 
-	fp := sources.NewMultiFile([]string{sourceFile}, blockSize, nil, numOfReaders, true)
+	sourceParams := &sources.MultiFileParams{
+		SourcePatterns:   []string{sourceFile},
+		BlockSize:        blockSize,
+		FilesPerPipeline: filesPerPipeline,
+		NumOfPartitions:  numOfReaders,
+		MD5:              true}
+
+	fp := sources.NewMultiFile(sourceParams)[0]
 	ap := targets.NewAzureBlock(accountName, accountKey, container)
 	tfer := NewTransfer(&fp, &ap, numOfReaders, numOfWorkers, blockSize)
 	tfer.StartTransfer(None, delegate)
@@ -156,7 +207,14 @@ func TestFileToBlobHTTPToFile(t *testing.T) {
 	container, _ := getContainers()
 	var sourceFile = createFile("tb", 1)
 
-	fp := sources.NewMultiFile([]string{sourceFile}, blockSize, nil, numOfReaders, true)
+	sourceParams := &sources.MultiFileParams{
+		SourcePatterns:   []string{sourceFile},
+		BlockSize:        blockSize,
+		FilesPerPipeline: filesPerPipeline,
+		NumOfPartitions:  numOfReaders,
+		MD5:              true}
+
+	fp := sources.NewMultiFile(sourceParams)[0]
 	ap := targets.NewAzureBlock(accountName, accountKey, container)
 	tfer := NewTransfer(&fp, &ap, numOfReaders, numOfWorkers, blockSize)
 	tfer.StartTransfer(None, delegate)
@@ -180,14 +238,29 @@ func TestFileToBlobToFile(t *testing.T) {
 	container, _ := getContainers()
 	var sourceFile = createFile("tb", 1)
 
-	fp := sources.NewMultiFile([]string{sourceFile}, blockSize, nil, numOfReaders, true)
+	sourceParams := &sources.MultiFileParams{
+		SourcePatterns:   []string{sourceFile},
+		BlockSize:        blockSize,
+		FilesPerPipeline: filesPerPipeline,
+		NumOfPartitions:  numOfReaders,
+		MD5:              true}
+
+	fp := sources.NewMultiFile(sourceParams)[0]
 	ap := targets.NewAzureBlock(accountName, accountKey, container)
 	tfer := NewTransfer(&fp, &ap, numOfReaders, numOfWorkers, blockSize)
 	tfer.StartTransfer(None, delegate)
 	tfer.WaitForCompletion()
 
 	ap = targets.NewMultiFile(true, numOfWorkers)
-	fp = sources.NewAzureBlob(container, []string{sourceFile}, accountName, accountKey, true, false)
+	azureBlobParams := &sources.AzureBlobParams{
+		Container:         container,
+		BlobNames:         []string{sourceFile},
+		AccountName:       accountName,
+		AccountKey:        accountKey,
+		FilesPerPipeline:  filesPerPipeline,
+		CalculateMD5:      true,
+		UseExactNameMatch: false}
+	fp = sources.NewAzureBlob(azureBlobParams)[0]
 	tfer = NewTransfer(&fp, &ap, numOfReaders, numOfWorkers, blockSize)
 	tfer.StartTransfer(None, delegate)
 	tfer.WaitForCompletion()
@@ -200,14 +273,30 @@ func TestFileToBlobToFileWithAlias(t *testing.T) {
 	var sourceFile = createFile("tb", 1)
 	var alias = "x" + sourceFile
 
-	fp := sources.NewMultiFile([]string{sourceFile}, blockSize, []string{alias}, numOfReaders, true)
+	sourceParams := &sources.MultiFileParams{
+		SourcePatterns:   []string{sourceFile},
+		BlockSize:        blockSize,
+		TargetAliases:    []string{alias},
+		FilesPerPipeline: filesPerPipeline,
+		NumOfPartitions:  numOfReaders,
+		MD5:              true}
+
+	fp := sources.NewMultiFile(sourceParams)[0]
 	ap := targets.NewAzureBlock(accountName, accountKey, container)
 	tfer := NewTransfer(&fp, &ap, numOfReaders, numOfWorkers, blockSize)
 	tfer.StartTransfer(None, delegate)
 	tfer.WaitForCompletion()
 
 	ap = targets.NewMultiFile(true, numOfWorkers)
-	fp = sources.NewAzureBlob(container, []string{alias}, accountName, accountKey, true, false)
+	azureBlobParams := &sources.AzureBlobParams{
+		Container:         container,
+		BlobNames:         []string{alias},
+		AccountName:       accountName,
+		AccountKey:        accountKey,
+		CalculateMD5:      true,
+		FilesPerPipeline:  filesPerPipeline,
+		UseExactNameMatch: false}
+	fp = sources.NewAzureBlob(azureBlobParams)[0]
 	tfer = NewTransfer(&fp, &ap, numOfReaders, numOfWorkers, blockSize)
 	tfer.StartTransfer(None, delegate)
 	tfer.WaitForCompletion()

--- a/transfer/transferstats.go
+++ b/transfer/transferstats.go
@@ -1,0 +1,66 @@
+package transfer
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Azure/blobporter/util"
+)
+
+//Stats TODO
+type Stats struct {
+	workers int
+	readers int
+	values  []StatInfo
+}
+
+//StatInfo TODO
+type StatInfo struct {
+	NumberOfFiles       int
+	Duration            time.Duration
+	TargetRetries       int32
+	TotalNumberOfBlocks int
+	TotalSize           uint64
+	CumWriteDuration    time.Duration
+}
+
+//NewStats  TODO
+func NewStats(numberOfWorkers int, numberOfReaders int) *Stats {
+	return &Stats{workers: numberOfWorkers, readers: numberOfReaders, values: make([]StatInfo, 0)}
+}
+
+//AddTransferInfo TODO
+func (t *Stats) AddTransferInfo(info *StatInfo) {
+	t.values = append(t.values, (*info))
+}
+
+func (t *Stats) calcAggretagedValues() *StatInfo {
+	agg := StatInfo{}
+
+	for _, r := range t.values {
+		agg.NumberOfFiles = agg.NumberOfFiles + r.NumberOfFiles
+		agg.TargetRetries = agg.TargetRetries + r.TargetRetries
+		agg.TotalNumberOfBlocks = agg.TotalNumberOfBlocks + r.TotalNumberOfBlocks
+		agg.TotalSize = agg.TotalSize + r.TotalSize
+		agg.Duration = time.Duration(agg.Duration.Nanoseconds() + r.Duration.Nanoseconds())
+		agg.CumWriteDuration = time.Duration(agg.CumWriteDuration.Nanoseconds() + r.CumWriteDuration.Nanoseconds())
+	}
+
+	return &agg
+}
+
+//DisplaySummary TODO
+func (t *Stats) DisplaySummary() {
+
+	agg := t.calcAggretagedValues()
+
+	var netMB float64 = 1000000
+	fmt.Printf("\nThe data transfer took %v to run.\n", agg.Duration)
+	MBs := float64(agg.TotalSize) / netMB / agg.Duration.Seconds()
+	fmt.Printf("Throughput: %1.2f MB/s (%1.2f Mb/s) \n", MBs, MBs*8)
+	fmt.Printf("Configuration: R=%d, W=%d, DataSize=%s, Blocks=%d\n",
+		t.readers, t.workers, util.PrintSize(agg.TotalSize), agg.TotalNumberOfBlocks)
+	fmt.Printf("Cumulative Writes Duration: Total=%v, Avg Per Worker=%v\n",
+		agg.CumWriteDuration, time.Duration(agg.CumWriteDuration.Nanoseconds()/int64(t.workers)))
+	fmt.Printf("Retries: Avg=%v Total=%v\n", float32(agg.TargetRetries)/float32(agg.TotalNumberOfBlocks), agg.TargetRetries)
+}

--- a/util/util.go
+++ b/util/util.go
@@ -392,6 +392,8 @@ func getSuggestion(err error) string {
 		return "Try using a different container or upload and then delete a small blob with the same name."
 	case strings.Contains(err.Error(), "Client.Timeout"):
 		return "Try increasing the timeout using the -s option or reducing the number of workers and readers, options: -r and -g"
+	case strings.Contains(err.Error(),"too many open files"):
+		return "Try increasing the number of open files allowed. For debian systems you can try: ulimit -Sn 2048 "
 	default:
 		return ""
 	}


### PR DESCRIPTION
 - New options related to batch transfers:
 - - x, number of files per batch tranfer (default 200).
 - - Max number of handles for linux is calculated by the number of sources times number of handles per file.
 - - h, handles per file, default 2.
 - Preprocess of sources occur concurrently.
 - Default blocksize for blocks is 8MB instead of 4 MB
 - Reduced default per core number of readers and workers (5, 8).
 - p option keeps the directory structure from storage account while downloading from the storage account.