### PR TITLE
Download empty files (Fixes #102)

### DIFF
--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -229,6 +229,11 @@ func ConstructPartsQueue(size uint64, blockSize uint64, sourceURI string, target
 	var bsib = blockSize
 	numOfBlocks = int((size + (bsib - 1)) / bsib)
 
+	// Have at least 1 block.
+	if numOfBlocks == 0 {
+		numOfBlocks = 1
+	}
+
 	parts = make([]Part, numOfBlocks)
 
 	var curFileOffset uint64


### PR DESCRIPTION
This provides a fix for downloading empty files (#102).

I don't know if this fix is 100% the right way to do it. This PR forces 1 block, so that it is sent to the target pipeline - which will create the file.